### PR TITLE
Implement binary and string UUIDs

### DIFF
--- a/src/surreal/private/cbor/encoder.nim
+++ b/src/surreal/private/cbor/encoder.nim
@@ -119,11 +119,19 @@ proc encode*(writer: CborWriter, value: SurrealValue) =
         let bytes = value.toBytes()
         writer.encodeHead(String, bytes.len.uint64)
         writer.writeBytes(bytes)
+
     of SurrealTable:
         writer.encodeHead(Tag, TagTableName.uint64)
         let bytes = value.toBytes()
         writer.encodeHead(String, bytes.len.uint64)
         writer.writeBytes(bytes)
+
+    of SurrealUuid:
+        let bytes = value.getUuid
+        writer.encodeHead(Tag, TagUuidBinary.uint64)
+        writer.encodeHeadByte(Bytes, Sixteen)
+        writer.writeBytes(bytes)
+
     else:
         raise newException(ValueError, "Cannot encode a $1 value" % $value.kind)
 

--- a/src/surreal/private/types/surrealValue.nim
+++ b/src/surreal/private/types/surrealValue.nim
@@ -19,6 +19,7 @@ type
         SurrealRecordId,
         SurrealString,
         SurrealTable,
+        SurrealUuid,
 
         # TODO: There seem to be new Future and Range tags:
         # https://github.com/surrealdb/surrealdb/pull/4862
@@ -75,6 +76,8 @@ type
             stringVal: string
         of SurrealTable:
             tableVal: TableName
+        of SurrealUuid:
+            uuidVal: array[16, uint8]
 
 include values/[
     array,
@@ -88,6 +91,7 @@ include values/[
     map,
     string,
     table,
+    uuid,
 
     record,
 
@@ -128,3 +132,5 @@ func `==`*(a, b: SurrealValue): bool =
         return a.stringVal == b.stringVal
     of SurrealTable:
         return a.tableVal == b.tableVal
+    of SurrealUuid:
+        return a.uuidVal == b.uuidVal

--- a/src/surreal/private/types/values/shared.nim
+++ b/src/surreal/private/types/values/shared.nim
@@ -99,6 +99,16 @@ proc `$`*(value: SurrealValue): string =
         return value.stringVal.escapeString
     of SurrealTable:
         return value.tableVal.string
+    of SurrealUuid:
+        let v = value.uuidVal
+        return "u\"" &
+          v[0].toHex & v[1].toHex & v[2].toHex & v[3].toHex &
+            "-" & v[4].toHex & v[5].toHex &
+            "-" & v[6].toHex & v[7].toHex &
+            "-" & v[8].toHex & v[9].toHex &
+            "-" & v[10].toHex & v[11].toHex & v[12].toHex & v[13].toHex & v[14].toHex & v[15].toHex &
+          "\""
+
     else:
         raise newException(ValueError, "Cannot convert a $1 value to a string" % $value.kind)
 

--- a/src/surreal/private/types/values/uuid.nim
+++ b/src/surreal/private/types/values/uuid.nim
@@ -1,0 +1,59 @@
+
+proc toSurrealUuid*(value: array[16, uint8]): SurrealValue =
+    ## Converts a sequence of bytes to a SurrealUuid
+    return SurrealValue(kind: SurrealUuid, uuidVal: value)
+
+proc toSurrealUuid*(value: openArray[uint8]): SurrealValue =
+    ## Converts a sequence of bytes to a SurrealUuid
+    if value.len != 16:
+        raise newException(ValueError, "UUID is expected to be of length of 16 bytes")
+    let a: array[16, uint8] = [
+        value[0], value[1], value[2], value[3],
+        value[4], value[5], value[6], value[7],
+        value[8], value[9], value[10], value[11],
+        value[12], value[13], value[14], value[15]
+    ]
+    return SurrealValue(kind: SurrealUuid, uuidVal: a)
+
+proc toSurrealUuid*(value: string): SurrealValue =
+    ## Converts a string to a SurrealValue
+    # Match UUUId format with regex
+    let uuidParts = value.match(re"([0-9a-fA-F]{8})-?([0-9a-fA-F]{4})-?([0-9a-fA-F]{4})-?([0-9a-fA-F]{4})-?([0-9a-fA-F]{12})")
+    if uuidParts.len != 1 + 5 or uuidParts[0].len == 0:
+        raise newException(ValueError, "Invalid UUID format: " & value)
+    # Parse hex character pairs into uint8s
+    # TODO: This begs for optimization
+    var a: array[16, uint8] = [
+        parseHexInt(uuidParts[1][0..<2]).uint8,
+        parseHexInt(uuidParts[1][2..<4]).uint8,
+        parseHexInt(uuidParts[1][4..<6]).uint8,
+        parseHexInt(uuidParts[1][6..<8]).uint8,
+        parseHexInt(uuidParts[2][0..<2]).uint8,
+        parseHexInt(uuidParts[2][2..<4]).uint8,
+        parseHexInt(uuidParts[3][0..<2]).uint8,
+        parseHexInt(uuidParts[3][2..<4]).uint8,
+        parseHexInt(uuidParts[4][0..<2]).uint8,
+        parseHexInt(uuidParts[4][2..<4]).uint8,
+        parseHexInt(uuidParts[5][0..<2]).uint8,
+        parseHexInt(uuidParts[5][2..<4]).uint8,
+        parseHexInt(uuidParts[5][4..<6]).uint8,
+        parseHexInt(uuidParts[5][6..<8]).uint8,
+        parseHexInt(uuidParts[5][8..<10]).uint8,
+        parseHexInt(uuidParts[5][10..<12]).uint8,
+    ]
+    return SurrealValue(kind: SurrealUuid, uuidVal: a)
+
+proc uuid*(stringId: string): SurrealValue =
+    ## Creates a new UUID object from a string representation.
+    return stringId.toSurrealUuid()
+
+proc getUuid*(value: SurrealValue): seq[uint8] =
+    ## Converts bytes array from SurrealBytes
+    case value.kind
+    of SurrealUuid:
+        return value.uuidVal.toSeq
+    else:
+        raise newException(ValueError, "The value is of type $1 and doesn't contain uuid bytes" % $value.kind)
+
+let zeroUuid* = [0'u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0].toSurrealUuid
+let maxUuid* = [255'u8, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255].toSurrealUuid

--- a/surrealdb.nimble
+++ b/surrealdb.nimble
@@ -47,6 +47,7 @@ task test, "General tests":
     "surrealvalue/test_surrealvalue_recordid.nim",
     "surrealvalue/test_surrealvalue_string.nim",
     "surrealvalue/test_surrealvalue_table.nim",
+    "surrealvalue/test_surrealvalue_uuid.nim",
 
     # CBOR
     "cbor/test_cbor_reader.nim",
@@ -65,6 +66,7 @@ task test, "General tests":
     "cbor/encoding/test_cbor_encoder_record.nim",
     "cbor/encoding/test_cbor_encoder_string.nim",
     "cbor/encoding/test_cbor_encoder_table.nim",
+    "cbor/encoding/test_cbor_encoder_uuid.nim",
 
     "cbor/decoding/test_cbor_decoder_array.nim",
     "cbor/decoding/test_cbor_decoder_bool.nim",
@@ -78,7 +80,7 @@ task test, "General tests":
     "cbor/decoding/test_cbor_decoder_record.nim",
     "cbor/decoding/test_cbor_decoder_string.nim",
     "cbor/decoding/test_cbor_decoder_table.nim",
-    "cbor/decoding/test_cbor_decoder_surrealdb_responses.nim",
+    "cbor/decoding/test_cbor_decoder_uuid.nim",
 
     "cbor/test_cbor_encoding.nim"
   ]:

--- a/tests/cbor/decoding/test_cbor_decoder_uuid.nim
+++ b/tests/cbor/decoding/test_cbor_decoder_uuid.nim
@@ -1,0 +1,32 @@
+import std/unittest
+import surreal/private/cbor/[decoder, encoder, types, writer]
+import surreal/private/types/[surrealValue]
+
+suite "CBOR:Decoder:Uuid":
+
+    test "decode binary uuid":
+        const data = @[
+            encodeHeadByte(Tag, OneByte),
+            37, # Binery UUID
+            encodeHeadByte(Bytes, Sixteen),
+            191, 152, 22, 41, 4, 254, 190, 102, 20, 59, 164, 85, 1, 0, 255, 35
+        ]
+        let decoded = decode(data)
+        check(decoded.kind == SurrealUuid)
+        let bytes = decoded.getUuid
+        check(bytes == @[191'u8, 152, 22, 41, 4, 254, 190, 102, 20, 59, 164, 85, 1, 0, 255, 35])
+
+    test "decode string uuid":
+        const data = @[
+            encodeHeadByte(Tag, Nine),
+            encodeHeadByte(String, OneByte),
+            36, # String length
+            # 7839e750-4641-4cfa-8dea-449375145be3
+            0x37, 0x38, 0x33, 0x39, 0x65, 0x37, 0x35, 0x30, 0x2d, 0x34, 0x36, 0x34,
+            0x31, 0x2d, 0x34, 0x63, 0x66, 0x61, 0x2d, 0x38, 0x64, 0x65, 0x61, 0x2d,
+            0x34, 0x34, 0x39, 0x33, 0x37, 0x35, 0x31, 0x34, 0x35, 0x62, 0x65, 0x33
+        ]
+        let decoded = decode(data)
+        check(decoded.kind == SurrealUuid)
+        let bytes = decoded.getUuid
+        check(bytes == @[120'u8, 57, 231, 80, 70, 65, 76, 250, 141, 234, 68, 147, 117, 20, 91, 227])

--- a/tests/cbor/encoding/test_cbor_encoder_uuid.nim
+++ b/tests/cbor/encoding/test_cbor_encoder_uuid.nim
@@ -1,0 +1,14 @@
+import std/[sequtils, unittest]
+import surreal/private/cbor/[encoder, writer]
+import surreal/private/types/[surrealValue]
+
+suite "CBOR:Encoder:Uuid":
+
+    test "should encode UUID value":
+        let value = uuid"7839e750-4641-4cfa-8dea-449375145be3"
+        let bytes = encode(%%% value).getOutput()
+        check(bytes == @[
+            0b110_11000'u8, 37, # Tag - 1 byte to encode the tag 37
+            0b010_10000'u8, # 16 bytes
+            120, 57, 231, 80, 70, 65, 76, 250, 141, 234, 68, 147, 117, 20, 91, 227
+        ]) 

--- a/tests/cbor/test_cbor_encoding.nim
+++ b/tests/cbor/test_cbor_encoding.nim
@@ -304,3 +304,18 @@ suite "CBOR:Encoding":
         let surrealValue = decode(writer.getOutput())
         check(surrealValue.kind == SurrealDatetime)
         check(surrealValue == datetime)
+
+    test "encode and decode UUID":
+        let uuid1 = "25FF15F4-0E8D-4EA7-8E0B-BFF976264AC5"
+        let surrealValue = uuid1.toSurrealUuid()
+        let writer = encode(surrealValue)
+        let decoded = decode(writer.getOutput())
+        check(decoded.kind == SurrealUuid)
+        check(decoded.getUuid == uuid1.toSurrealUuid.getUuid)
+        
+        let uuid2 = "5C5E7A6C-B582-4A87-A209-30FE73ADD92C"
+        let surrealValue2 = uuid2.toSurrealUuid()
+        let writer2 = encode(surrealValue2)
+        let decoded2 = decode(writer2.getOutput())
+        check(decoded2.kind == SurrealUuid)
+        check(decoded2.getUuid == uuid2.toSurrealUuid.getUuid)

--- a/tests/surrealvalue/test_surrealvalue_uuid.nim
+++ b/tests/surrealvalue/test_surrealvalue_uuid.nim
@@ -1,0 +1,83 @@
+import std/[sequtils, unittest]
+import surreal/private/types/[surrealValue]
+
+suite "SurrealValue:Uuid":
+
+    test "Can be created from a string":
+        const value1 = "e6d6a0a9-e2d7-4f9c-b8a8-d0b5e3d1f8d8"
+        var surrealValue = value1.toSurrealUuid()
+        check(surrealValue.kind == SurrealUuid)
+        check(surrealValue.getUuid == @[230'u8, 214, 160, 169, 226, 215, 79, 156, 184, 168, 208, 181, 227, 209, 248, 216])
+        const value2 = "BA8c31E1-DD3f-4D2B-A3E3-F0E5B4C2a0B0"
+        surrealValue = value2.toSurrealUuid()
+        check(surrealValue.kind == SurrealUuid)
+        check(surrealValue.getUuid == @[186'u8, 140, 49, 225, 221, 63, 77, 43, 163, 227, 240, 229, 180, 194, 160, 176])
+        const value3 = "e6d6a0a9e2d74f9cb8a8d0b5e3d1f8d8"
+        surrealValue = value3.toSurrealUuid()
+        check(surrealValue.kind == SurrealUuid)
+        check(surrealValue.getUuid == @[230'u8, 214, 160, 169, 226, 215, 79, 156, 184, 168, 208, 181, 227, 209, 248, 216])
+        const value4 = "BA8C31E1DD3F4D2BA3E3F0E5B4C2A0B0"
+        surrealValue = value4.toSurrealUuid()
+        check(surrealValue.kind == SurrealUuid)
+        check(surrealValue.getUuid == @[186'u8, 140, 49, 225, 221, 63, 77, 43, 163, 227, 240, 229, 180, 194, 160, 176])
+        const value5 = "e6D6a0A9-e2D74f9c-b8A8-d0b5e3d1f8d8"
+        surrealValue = value5.toSurrealUuid()
+        check(surrealValue.kind == SurrealUuid)
+        check(surrealValue.getUuid == @[230'u8, 214, 160, 169, 226, 215, 79, 156, 184, 168, 208, 181, 227, 209, 248, 216])
+        const value6 = "BA8c31E1DD3f-4D2BA3E3F0E5b4C2a0B0"
+        surrealValue = value6.toSurrealUuid()
+        check(surrealValue.kind == SurrealUuid)
+        check(surrealValue.getUuid == @[186'u8, 140, 49, 225, 221, 63, 77, 43, 163, 227, 240, 229, 180, 194, 160, 176])
+
+        surrealValue = uuid"00000000-0000-0000-0000-000000000000"
+        check(surrealValue.kind == SurrealUuid)
+        check(surrealValue == zeroUuid)
+        check(surrealValue.getUuid == zeroUuid.getUuid)
+        
+        surrealValue = uuid"ffffffff-ffff-ffff-ffff-ffffffffffff"
+        check(surrealValue.kind == SurrealUuid)
+        check(surrealValue == maxUuid)
+        check(surrealValue.getUuid == maxUuid.getUuid)
+
+    test "Can be created from a sequence of bytes":
+        const value1: seq[uint8] = @[230'u8, 214, 160, 169, 226, 215, 79, 156, 184, 168, 208, 181, 227, 209, 248, 216]
+        var surrealValue = value1.toSurrealUuid()
+        check(surrealValue.kind == SurrealUuid)
+        check(surrealValue.getUuid == value1)
+        
+        const value2: seq[uint8] = @[43'u8, 150, 136, 31, 97, 201, 2, 48, 32, 32, 250, 190, 113, 221, 16, 88]
+        surrealValue = value2.toSurrealUuid()
+        check(surrealValue.kind == SurrealUuid)
+        check(surrealValue.getUuid == value2.toSeq)
+
+    test "Can be created from an array of bytes":
+        const value1: array[16, uint8] = [230'u8, 214, 160, 169, 226, 215, 79, 156, 184, 168, 208, 181, 227, 209, 248, 216]
+        var surrealValue = value1.toSurrealUuid()
+        check(surrealValue.kind == SurrealUuid)
+        check(surrealValue.getUuid == value1)
+
+        const value2: array[16, uint8] = [43'u8, 150, 136, 31, 97, 201, 2, 48, 32, 32, 250, 190, 113, 221, 16, 88]
+        surrealValue = value2.toSurrealUuid()
+        check(surrealValue.kind == SurrealUuid)
+        check(surrealValue.getUuid == value2.toSeq)
+
+    test "Can compare UUIDs":
+        let uuid1 = uuid"00000000-0000-0000-0000-000000000000"
+        let uuid2 = uuid"00000000-0000-0000-0000-000000000000"
+        check(uuid1 == uuid2)
+
+        check(zeroUuid == zeroUuid)
+        check(maxUuid == maxUuid)
+        check(zeroUuid != maxUuid)
+        check(maxUuid != zeroUuid)
+
+        let uuid3 = uuid"abcdef01-2345-6789-abcd-ef0123456789"
+        let uuid4 = uuid"abcdef01-2345-6789-abcd-ef0123456789"
+        check(uuid3 == uuid4)
+
+    test "Can print out UUIDs":
+        let uuid1 = uuid"00000000-0000-0000-0000-000000000000"
+        check($uuid1 == "u\"00000000-0000-0000-0000-000000000000\"")
+
+        let uuid2 = uuid"ABCDEF01-2345-6789-ABCD-EF0123456789"
+        check($uuid2 == "u\"ABCDEF01-2345-6789-ABCD-EF0123456789\"")


### PR DESCRIPTION
- Implements and tests the `SurrealUuid` variant of `SurrealValue`
- Implements and tests decoding of both string and binary UUIDs
- Implements and tests encoding of binary UUIDs. Encoding of string UUIDs is omitted as binary representation is more efficient and preferred by SurrealDB.

Closes #9
Closes #16 