### PR TITLE
Add unbound start/end support to SurrealRange

### DIFF
--- a/src/surreal/private/cbor/encoder.nim
+++ b/src/surreal/private/cbor/encoder.nim
@@ -128,11 +128,25 @@ proc encode*(writer: CborWriter, value: SurrealValue) =
         ]
         writer.writeBytes(initialBytes)
         # Start value
-        writer.encodeHead(Tag, if value.isRangeStartInclusive: TagBoundIncluded.uint64 else: TagBoundExcluded.uint64)
-        writer.encode(value.getRangeStart())
+        case value.getStartBound:
+        of Unbounded:
+            writer.writeBytes(noneBytes)
+        of Inclusive:
+            writer.writeBytes([0b110_11000'u8, TagBoundIncluded.uint8])
+            writer.encode(value.getRangeStart())
+        of Exclusive:
+            writer.writeBytes([0b110_11000'u8, TagBoundExcluded.uint8])
+            writer.encode(value.getRangeStart())
         # End value
-        writer.encodeHead(Tag, if value.isRangeEndInclusive: TagBoundIncluded.uint64 else: TagBoundExcluded.uint64)
-        writer.encode(value.getRangeEnd())
+        case value.getEndBound:
+        of Unbounded:
+            writer.writeBytes(noneBytes)
+        of Inclusive:
+            writer.writeBytes([0b110_11000'u8, TagBoundIncluded.uint8])
+            writer.encode(value.getRangeEnd())
+        of Exclusive:
+            writer.writeBytes([0b110_11000'u8, TagBoundExcluded.uint8])
+            writer.encode(value.getRangeEnd())
 
     of SurrealRecordId:
         const initialBytes = [

--- a/src/surreal/private/types/values/range.nim
+++ b/src/surreal/private/types/values/range.nim
@@ -1,53 +1,64 @@
 
 proc newSurrealRange*(startValue: SurrealValue, endValue: SurrealValue, isStartInclusive: bool, isEndInclusive: bool): SurrealValue =
-    ## Converts a tuple of SurrealValues to a SurrealRange
-    return SurrealValue(kind: SurrealRange, rangeStartVal: startValue, rangeEndVal: endValue,
-        isRangeStartInclusive: isStartInclusive, isRangeEndInclusive: isEndInclusive)
+    ## Create a new SurrealRange with both start and end values
+    case isStartInclusive:
+    of true:
+        case isEndInclusive:
+        of true:
+            return SurrealValue(kind: SurrealRange, rangeStartBound: Inclusive, rangeStartVal: startValue, rangeEndBound: Inclusive, rangeEndVal: endValue)
+        of false:
+            return SurrealValue(kind: SurrealRange, rangeStartBound: Inclusive, rangeStartVal: startValue, rangeEndBound: Exclusive, rangeEndVal: endValue)
+    of false:
+        case isEndInclusive:
+        of true:
+            return SurrealValue(kind: SurrealRange, rangeStartBound: Exclusive, rangeStartVal: startValue, rangeEndBound: Inclusive, rangeEndVal: endValue)
+        of false:
+            return SurrealValue(kind: SurrealRange, rangeStartBound: Exclusive, rangeStartVal: startValue, rangeEndBound: Exclusive, rangeEndVal: endValue)
+
+proc newSurrealStartOnlyRange*(startValue: SurrealValue, isStartInclusive: bool): SurrealValue =
+    ## Create a new SurrealRange with only start value - the end value is unbounded
+    case isStartInclusive:
+    of true:
+        return SurrealValue(kind: SurrealRange, rangeStartBound: Inclusive, rangeStartVal: startValue, rangeEndBound: Unbounded)
+    of false:
+        return SurrealValue(kind: SurrealRange, rangeStartBound: Exclusive, rangeStartVal: startValue, rangeEndBound: Unbounded)
+
+proc newSurrealEndOnlyRange*(endValue: SurrealValue, isEndInclusive: bool): SurrealValue =
+    ## Create a new SurrealRange with only end value - the start value is unbounded
+    case isEndInclusive:
+    of true:
+        return SurrealValue(kind: SurrealRange, rangeStartBound: Unbounded, rangeEndBound: Inclusive, rangeEndVal: endValue)
+    of false:
+        return SurrealValue(kind: SurrealRange, rangeStartBound: Unbounded, rangeEndBound: Exclusive, rangeEndVal: endValue)
 
 proc getRangeStart*(value: SurrealValue): SurrealValue =
-    ## Extracts the start value from the SurrealRange.
-    case value.kind
-    of SurrealRange:
-        return value.rangeStartVal
-    else:
+    ## Extracts the start value from the SurrealRange
+    if value.kind != SurrealRange:
         raise newException(ValueError, "Cannot extract the start value from a $1 value" % $value.kind)
+    return if value.rangeStartBound == Unbounded: surrealNone else: value.rangeStartVal
 
 proc getRangeEnd*(value: SurrealValue): SurrealValue =
     ## Extracts the end value from the SurrealRange.
-    case value.kind
-    of SurrealRange:
-        return value.rangeEndVal
-    else:
+    if value.kind != SurrealRange:
         raise newException(ValueError, "Cannot extract the end value from a $1 value" % $value.kind)
+    return if value.rangeEndBound == Unbounded: surrealNone else: value.rangeEndVal
 
 proc getRangeValues*(value: SurrealValue): (SurrealValue, SurrealValue) =
-    ## Extracts the start and end values from the SurrealRange.
-    case value.kind
-    of SurrealRange:
-        return (value.rangeStartVal, value.rangeEndVal)
-    else:
+    ## Extracts the start and end values from the SurrealRange
+    if value.kind != SurrealRange:
         raise newException(ValueError, "Cannot extract the start and end values from a $1 value" % $value.kind)
+    let startValue = if value.rangeStartBound == Unbounded: surrealNone else: value.rangeStartVal
+    let endValue = if value.rangeEndBound == Unbounded: surrealNone else: value.rangeEndVal
+    return (startValue, endValue)
 
-proc isRangeStartInclusive*(value: SurrealValue): bool =
-    ## Checks if the start value of the SurrealRange is inclusive.
-    case value.kind
-    of SurrealRange:
-        return value.isRangeStartInclusive
-    else:
-        raise newException(ValueError, "Cannot check the start value of a $1 value" % $value.kind)
+proc getStartBound*(value: SurrealValue): SurrealBoundKind =
+    ## Extracts the start bound from the SurrealRange
+    if value.kind != SurrealRange:
+        raise newException(ValueError, "Cannot extract the start bound from a $1 value" % $value.kind)
+    return value.rangeStartBound
 
-proc isRangeEndInclusive*(value: SurrealValue): bool =
-    ## Checks if the end value of the SurrealRange is inclusive.
-    case value.kind
-    of SurrealRange:
-        return value.isRangeEndInclusive
-    else:
-        raise newException(ValueError, "Cannot check the end value of a $1 value" % $value.kind)
-
-proc getRangeData*(value: SurrealValue): (SurrealValue, SurrealValue, bool, bool) =
-    ## Extracts the start, end, startInclusive and endInclusive values from the SurrealRange.
-    case value.kind
-    of SurrealRange:
-        return (value.rangeStartVal, value.rangeEndVal, value.isRangeStartInclusive, value.isRangeEndInclusive)
-    else:
-        raise newException(ValueError, "Cannot check the end value of a $1 value" % $value.kind)
+proc getEndBound*(value: SurrealValue): SurrealBoundKind =
+    ## Extracts the end bound from the SurrealRange
+    if value.kind != SurrealRange:
+        raise newException(ValueError, "Cannot extract the end bound from a $1 value" % $value.kind)
+    return value.rangeEndBound

--- a/src/surreal/private/types/values/shared.nim
+++ b/src/surreal/private/types/values/shared.nim
@@ -98,11 +98,22 @@ proc `$`*(value: SurrealValue): string =
                 text = text & "," & pair[0].escapeString & ":" & $pair[1]
             return text & "}"
     of SurrealRange:
+        let startBound = value.getStartBound
+        let endBound = value.getEndBound
         let operator =
-            if value.isRangeStartInclusive:
-                if value.isRangeEndInclusive: "..=" else: ".."
-            else:
-                if value.isRangeEndInclusive: ">..=" else: ">.."
+            case startBound:
+            of Unbounded, Inclusive:
+                case endBound:
+                of Unbounded, Exclusive:
+                    ".."
+                of Inclusive:
+                    "..="
+            of Exclusive:
+                case endBound:
+                of Unbounded, Exclusive:
+                    ">.."
+                of Inclusive:
+                    ">..="
         return $value.rangeStartVal & operator & $value.rangeEndVal
     of SurrealRecordId:
         return "<record> " & $value.recordVal
@@ -119,9 +130,93 @@ proc `$`*(value: SurrealValue): string =
             "-" & v[8].toHex & v[9].toHex &
             "-" & v[10].toHex & v[11].toHex & v[12].toHex & v[13].toHex & v[14].toHex & v[15].toHex &
           "\""
-
     else:
         raise newException(ValueError, "Cannot convert a $1 value to a string" % $value.kind)
+
+
+proc debugPrintSurrealValue*(value: SurrealValue): string =
+    # Prints the provided SurrealValue to the console with verbose formatting
+    case value.kind
+    of SurrealArray:
+        case value.arrayVal.len:
+        of 0: return "<<SurrealArray>>[]"
+        of 1: return "<<SurrealArray>>[" & value.arrayVal[0].debugPrintSurrealValue & "]"
+        else:
+            var text = "<<SurrealArray>>[" & value.arrayVal[0].debugPrintSurrealValue
+            for i in 1..<value.arrayVal.len:
+                text = text & "," & value.arrayVal[i].debugPrintSurrealValue
+            return text & "]"
+    of SurrealBool:
+        return "<<SurrealBool>>" & $value.boolVal
+    of SurrealBytes:
+        return "<<SurrealBool>>" & cast[string](value.bytesVal)
+    of SurrealDatetime:
+        # Print it as ISO 8601 string
+        return "<<SurrealDatatetime>>" & $value.getDateTime() & "\""
+    of SurrealDuration:
+        return "<<SurrealDuration>>" & $value.durationVal.seconds & "s" & $value.durationVal.nanoseconds & "ns\""
+    of SurrealFloat:
+        return case value.floatKind
+            of Float32: "<<SurrealFloat32>>" & $value.float32Val
+            of Float64: "<<SurrealFloat64>>" & $value.float64Val
+    of SurrealFuture:
+        return "<<SurrealFuture>>{ " & value.futureVal.debugPrintSurrealValue & " }"
+    of SurrealInteger:
+        # TODO: Handle large integers, including negative u64
+        return "<<SurrealInteger>>" & $(value.toInt64)
+    of SurrealNone:
+        return "<<SurrealNone>>NONE"
+    of SurrealNull:
+        return "<<SurrealNull>>NULL"
+    of SurrealObject:
+        case value.objectVal.len:
+        of 0: return "<<SurrealObject>>{}"
+        of 1:
+            let pair = value.objectVal.pairs.toSeq[0]
+            return "<<SurrealObject>>{" & pair[0].escapeString & ":" & pair[1].debugPrintSurrealValue & "}"
+        else:
+            let pairs = value.objectVal.pairs.toSeq
+            var text = "<<SurrealObject>>{" & pairs[0][0].escapeString & ":" & pairs[0][1].debugPrintSurrealValue
+            for i in 1..<pairs.len:
+                let pair = pairs[i]
+                text = text & "," & pair[0].escapeString & ":" & pair[1].debugPrintSurrealValue
+            return text & "}"
+    of SurrealRange:
+        let startBound = value.getStartBound
+        let endBound = value.getEndBound
+        let operator =
+            case startBound:
+            of Unbounded, Inclusive:
+                case endBound:
+                of Unbounded, Exclusive:
+                    ".."
+                of Inclusive:
+                    "..="
+            of Exclusive:
+                case endBound:
+                of Unbounded, Exclusive:
+                    ">.."
+                of Inclusive:
+                    ">..="
+        return "<<SurrealRange>>(" & value.rangeStartVal.debugPrintSurrealValue & ")" & operator & "(" & value.rangeEndVal.debugPrintSurrealValue & ")"
+    of SurrealRecordId:
+        return "<<SurrealRecordId>>(" & $value.recordVal & ")"
+    of SurrealString:
+        return "<<SurrealString>>" & value.stringVal.escapeString
+    of SurrealTable:
+        return "<<SurrealTable>>\"" & value.tableVal.string & "\""
+    of SurrealUuid:
+        let v = value.uuidVal
+        return "<<SurrealUuid>>\"" &
+          v[0].toHex & v[1].toHex & v[2].toHex & v[3].toHex &
+            "-" & v[4].toHex & v[5].toHex &
+            "-" & v[6].toHex & v[7].toHex &
+            "-" & v[8].toHex & v[9].toHex &
+            "-" & v[10].toHex & v[11].toHex & v[12].toHex & v[13].toHex & v[14].toHex & v[15].toHex &
+          "\""
+    else:
+        raise newException(ValueError, "Cannot convert a $1 value to a string debug representation" % $value.kind)
+
 
 template `%%%`*(v: SurrealValue): SurrealValue = v
 

--- a/tests/cbor/decoding/test_cbor_decoder_range.nim
+++ b/tests/cbor/decoding/test_cbor_decoder_range.nim
@@ -4,19 +4,37 @@ import surreal/private/types/[none, surrealValue]
 
 suite "CBOR:Decoder:Range":
 
-    test "can decode range":
+    test "can decode range with both bounds":
         var decoded = decode(@[0b110_11000'u8, 49, 0b100_00010'u8, 0b110_11000, 51, 0b000_00000, 0b110_11000, 50, 0b000_11000, 255])
         check(decoded.kind == SurrealRange)
         check(decoded.getRangeStart() == %%% 0)
         check(decoded.getRangeEnd() == %%% 255)
-        check(decoded.isRangeStartInclusive == false)
-        check(decoded.isRangeEndInclusive == true)
+        check(decoded.getStartBound() == Exclusive)
+        check(decoded.getEndBound() == Inclusive)
         check(decoded == newSurrealRange(%%% 0, %%% 255, false, true))
 
         decoded = decode(@[0b110_11000'u8, 49, 0b100_00010'u8, 0b110_11000, 50, 0b011_00010, 0x48, 0x69, 0b110_11000, 51, 0b110_00110, 0b111_10110])
         check(decoded.kind == SurrealRange)
         check(decoded.getRangeStart() == %%% "Hi")
         check(decoded.getRangeEnd() == %%% None)
-        check(decoded.isRangeStartInclusive == true)
-        check(decoded.isRangeEndInclusive == false)
+        check(decoded.getStartBound() == Inclusive)
+        check(decoded.getEndBound() == Exclusive)
         check(decoded == newSurrealRange(%%% "Hi", %%% None, true, false))
+
+    test "can decode range with only start bound":
+        var decoded = decode(@[0b110_11000'u8, 49, 0b100_00010'u8, 0b110_11000, 51, 0b000_00000, 0b110_00110, 0b111_10110])
+        check(decoded.kind == SurrealRange)
+        check(decoded.getRangeStart() == %%% 0)
+        check(decoded.getRangeEnd() == surrealNone)
+        check(decoded.getStartBound() == Exclusive)
+        check(decoded.getEndBound() == Unbounded)
+        check(decoded == newSurrealStartOnlyRange(%%% 0, false))
+
+    test "can decode range with only end bound":
+        var decoded = decode(@[0b110_11000'u8, 49, 0b100_00010'u8, 0b110_00110, 0b111_10110, 0b110_11000, 51, 0b110_00110, 0b111_10110])
+        check(decoded.kind == SurrealRange)
+        check(decoded.getRangeStart() == surrealNone)
+        check(decoded.getRangeEnd() == surrealNone)
+        check(decoded.getStartBound() == Unbounded)
+        check(decoded.getEndBound() == Exclusive)
+        check(decoded == newSurrealEndOnlyRange(%%% None, false))

--- a/tests/cbor/encoding/test_cbor_encoder_range.nim
+++ b/tests/cbor/encoding/test_cbor_encoder_range.nim
@@ -4,11 +4,21 @@ import surreal/private/types/[none, surrealValue]
 
 suite "CBOR:Encoder:Range":
 
-    test "should encode range":
+    test "should encode range with both bounds":
         var range = newSurrealRange(%%% 0, %%% 255, false, true)
         var bytes = encode(range).getOutput()
-        check(bytes == @[0b110_11000'u8, 49, 0b100_00010'u8, 0b110_11000, 51, 0b000_00000, 0b110_11000, 50, 0b000_11000, 255])
+        check(bytes == @[0b110_11000'u8, 49, 0b100_00010, 0b110_11000, 51, 0b000_00000, 0b110_11000, 50, 0b000_11000, 255])
 
         range = newSurrealRange(%%% "Hi", %%% None, true, false)
         bytes = encode(range).getOutput()
-        check(bytes == @[0b110_11000'u8, 49, 0b100_00010'u8, 0b110_11000, 50, 0b011_00010, 0x48, 0x69, 0b110_11000, 51, 0b110_00110, 0b111_10110])
+        check(bytes == @[0b110_11000'u8, 49, 0b100_00010, 0b110_11000, 50, 0b011_00010, 0x48, 0x69, 0b110_11000, 51, 0b110_00110, 0b111_10110])
+
+    test "should encode range with only start bound":
+        var range = newSurrealStartOnlyRange(%%% 255, true)
+        var bytes = encode(range).getOutput()
+        check(bytes == @[0b110_11000'u8, 49, 0b100_00010, 0b110_11000, 50, 0b000_11000, 255, 0b110_00110, 0b111_10110])
+
+    test "should encode range with only end bound":
+        var range = newSurrealEndOnlyRange(%%% "Hi", false)
+        var bytes = encode(range).getOutput()
+        check(bytes == @[0b110_11000'u8, 49, 0b100_00010, 0b110_00110, 0b111_10110, 0b110_11000, 51, 0b011_00010, 0x48, 0x69])

--- a/tests/surrealvalue/test_surrealvalue_range.nim
+++ b/tests/surrealvalue/test_surrealvalue_range.nim
@@ -3,18 +3,43 @@ import surreal/private/types/[surrealValue]
 
 suite "SurrealValue:Range":
 
-    test "Can create a range from two SurrealValues and bounds":
+    test "can create range with both bounds":
         let startValue = %%% 12
         let endValue = %%% 150
         let rangeValue = newSurrealRange(startValue, endValue, true, false)
         check(rangeValue.kind == SurrealRange)
         check(rangeValue.getRangeStart() == startValue)
         check(rangeValue.getRangeEnd() == endValue)
-        check(rangeValue.isRangeStartInclusive == true)
-        check(rangeValue.isRangeEndInclusive == false)
-        check(rangeValue.getRangeData() == (startValue, endValue, true, false))
+        check(rangeValue.getStartBound() == Inclusive)
+        check(rangeValue.getEndBound() == Exclusive)
+
+    test "can create range with only start bound":
+        let startValue = %%* [12]
+        let rangeValue = newSurrealStartOnlyRange(startValue, false)
+        check(rangeValue.kind == SurrealRange)
+        check(rangeValue.getRangeStart() == startValue)
+        check(rangeValue.getRangeEnd() == surrealNone)
+        check(rangeValue.getStartBound() == Exclusive)
+        check(rangeValue.getEndBound() == Unbounded)
+
+    test "can create range with only end bound":
+        let endValue = %%* { "value": 5812 }
+        let rangeValue = newSurrealEndOnlyRange(endValue, true)
+        check(rangeValue.kind == SurrealRange)
+        check(rangeValue.getRangeStart() == surrealNone)
+        check(rangeValue.getRangeEnd() == endValue)
+        check(rangeValue.getStartBound() == Unbounded)
+        check(rangeValue.getEndBound() == Inclusive)
 
     test "can compare ranges":
         let range1 = newSurrealRange(%%% -12.5'f64, %%% 8.9832'f64, false, true)
         let range2 = newSurrealRange(%%% -12.5'f64, %%% 8.9832'f64, false, true)
         check(range1 == range2)
+
+        let range3 = newSurrealStartOnlyRange(%%% "Howdy", true)
+        let range4 = newSurrealStartOnlyRange(%%% "Howdy", true)
+        check(range3 == range4)
+
+        let range5 = newSurrealEndOnlyRange(%%% "Sayonara", false)
+        let range6 = newSurrealEndOnlyRange(%%% "Sayonara", false)
+        check(range5 == range6)


### PR DESCRIPTION
SurrealRange needs to support possible lack of bounds (value) for either start or end.

In SurrealQL that would be:
```sql
RETURN ..15;
RETURN 15..;
```