### PR TITLE
Make ranges use Null instead of None for unbounded values

### DIFF
--- a/src/surreal/private/cbor/decoder.nim
+++ b/src/surreal/private/cbor/decoder.nim
@@ -191,47 +191,49 @@ proc decode*(reader: CborReader, head: tuple[major: HeadMajor, argument: HeadArg
 
             # Extract the start element inclusivity tag
             let (startTagHead, startTagArgument) = reader.readHead()
-            if startTagHead != Tag:
-                raise newException(ValueError, "Expected a range start tag to be inclusive or exclusive (tag 49), but got (major): " & $startTagHead & "(arg)" & $startTagArgument)
             var startBound: SurrealBoundKind = Unbounded
             var startValue = surrealNone
-            let startTagArg = reader.getFullArgument(startTagArgument)
-            case startTagArg:
-            of TagBoundIncluded.uint64:
-                startBound = Inclusive
-                startValue = decode(reader, reader.readHead())
-            of TagBoundExcluded.uint64:
-                startBound = Exclusive
-                startValue = decode(reader, reader.readHead())
-            of TagNone.uint64:
+            case startTagHead:
+            of Tag:
+                let startTagArg = reader.getFullArgument(startTagArgument)
+                case startTagArg:
+                of TagBoundIncluded.uint64:
+                    startBound = Inclusive
+                    startValue = decode(reader, reader.readHead())
+                of TagBoundExcluded.uint64:
+                    startBound = Exclusive
+                    startValue = decode(reader, reader.readHead())
+                else:
+                    raise newException(ValueError, "Expected a range start tag to be inclusive or exclusive, but got (major)" & $startTagHead & "(arg)" & $startTagArg)
+            of Simple:
+                if startTagArgument != TwentyTwo:
+                    raise newException(ValueError, "Expected a range start to be NULL, but got (major)" & $startTagHead & "(arg)" & $startTagArgument)
                 startBound = Unbounded
-                let noneValue = reader.readBytes(1)[0]
-                if noneValue != nullByte:
-                    raise newException(ValueError, "None tag for range start contains non-none value")
             else:
-                raise newException(ValueError, "Expected a range start tag to be inclusive or exclusive (tag 49), but got (major): " & $startTagHead & "(arg)" & $startTagArgument)
+                raise newException(ValueError, "Expected a range start tag to be inclusive or exclusive (tag 49), but got (major)" & $startTagHead & "(arg)" & $startTagArgument)
             
             # Extract the end element inclusivity tag
             let (endTagHead, endTagArgument) = reader.readHead()
-            if endTagHead != Tag:
-                raise newException(ValueError, "Expected a range end tag to be inclusive or exclusive (tag 49), but got (major): " & $endTagHead & "(arg)" & $endTagArgument)
             var endBound: SurrealBoundKind = Unbounded
             var endValue = surrealNone
-            let endTagArg = reader.getFullArgument(endTagArgument)
-            case endTagArg:
-            of TagBoundIncluded.uint64:
-                endBound = Inclusive
-                endValue = decode(reader, reader.readHead())
-            of TagBoundExcluded.uint64:
-                endBound = Exclusive
-                endValue = decode(reader, reader.readHead())
-            of TagNone.uint64:
+            case endTagHead:
+            of Tag:
+                let endTagArg = reader.getFullArgument(endTagArgument)
+                case endTagArg:
+                of TagBoundIncluded.uint64:
+                    endBound = Inclusive
+                    endValue = decode(reader, reader.readHead())
+                of TagBoundExcluded.uint64:
+                    endBound = Exclusive
+                    endValue = decode(reader, reader.readHead())
+                else:
+                    raise newException(ValueError, "Expected a range end tag to be inclusive or exclusive, but got (major)" & $endTagHead & "(arg)" & $endTagArg)
+            of Simple:
+                if endTagArgument != TwentyTwo:
+                    raise newException(ValueError, "Expected a range end to be NULL, but got (major)" & $endTagHead & "(arg)" & $endTagArgument)
                 endBound = Unbounded
-                let noneValue = reader.readBytes(1)[0]
-                if noneValue != nullByte:
-                    raise newException(ValueError, "None tag for range end contains non-none value")
             else:
-                raise newException(ValueError, "Expected a range end tag to be inclusive or exclusive (tag 49), but got (major): " & $endTagHead & "(arg)" & $endTagArgument)
+                raise newException(ValueError, "Expected a range end tag to be inclusive or exclusive (tag 49), but got (major)" & $endTagHead & "(arg)" & $endTagArgument)
 
             case startBound:
             of Unbounded:

--- a/src/surreal/private/cbor/encoder.nim
+++ b/src/surreal/private/cbor/encoder.nim
@@ -130,7 +130,7 @@ proc encode*(writer: CborWriter, value: SurrealValue) =
         # Start value
         case value.getStartBound:
         of Unbounded:
-            writer.writeBytes(noneBytes)
+            writer.writeRawUInt(nullByte)
         of Inclusive:
             writer.writeBytes([0b110_11000'u8, TagBoundIncluded.uint8])
             writer.encode(value.getRangeStart())
@@ -140,7 +140,7 @@ proc encode*(writer: CborWriter, value: SurrealValue) =
         # End value
         case value.getEndBound:
         of Unbounded:
-            writer.writeBytes(noneBytes)
+            writer.writeRawUInt(nullByte)
         of Inclusive:
             writer.writeBytes([0b110_11000'u8, TagBoundIncluded.uint8])
             writer.encode(value.getRangeEnd())

--- a/src/surreal/private/logic/listenLoop.nim
+++ b/src/surreal/private/logic/listenLoop.nim
@@ -19,7 +19,7 @@ proc startListenLoop*(db: SurrealDB) {.async.} =
         of Opcode.Binary:
             # Parse the message as CBOR
             # echo "Received message (string): " & $message
-            let data = cast[seq[uint8]](message)
+            # let data = cast[seq[uint8]](message)
             # echo "Received message (raw): ", data
             let decodedMessage = decode(cast[seq[uint8]](message)) # TODO: Handle decoding errors
             # echo "Received message of kind: ", decodedMessage.kind
@@ -53,6 +53,10 @@ proc startListenLoop*(db: SurrealDB) {.async.} =
             # Otherwise, complete the future with the response content
             else:
                 future.complete(surrealResponseValue(decodedMessage["result"]))
+        of Opcode.Ping, Opcode.Pong:
+            # Ignore ping and pong messages
+            continue
         else:
-            # Ignore non-text and non-binary messages
+            # Log unexpected messages
+            echo "Received non-text and non-binary message: (", opcode, ") ", message
             continue

--- a/src/surreal/private/types/values/record.nim
+++ b/src/surreal/private/types/values/record.nim
@@ -44,9 +44,11 @@ proc escapeIdPart*(id: SurrealValue): string =
     # TODO: Support decimals (bigint)
     # of SurrealDecimal:
     #     return escapeDecimal(id.getDecimal)
-    # TODO: Support UUIDs
-    # of SurrealUuid:
-    #     return "`u\"" & id.getUuid & "\"`"
+    of SurrealRange:
+        return $id
+    of SurrealUuid:
+        return $id
+
     else:
         raise newException(ValueError, "Cannot escape the ID part of a record ID from a $1 value" % $id.kind)
 

--- a/src/surreal/private/types/values/shared.nim
+++ b/src/surreal/private/types/values/shared.nim
@@ -114,7 +114,19 @@ proc `$`*(value: SurrealValue): string =
                     ">.."
                 of Inclusive:
                     ">..="
-        return $value.rangeStartVal & operator & $value.rangeEndVal
+        case startBound:
+        of Inclusive, Exclusive:
+            case endBound:
+            of Inclusive, Exclusive:
+                return "(" & $value.rangeStartVal & operator & $value.rangeEndVal & ")"
+            of Unbounded:
+                return "(" & $value.rangeStartVal & operator & ")"
+        of Unbounded:
+            case endBound:
+            of Inclusive, Exclusive:
+                return "(" & operator & $value.rangeEndVal & ")"
+            of Unbounded:
+                return "(" & operator & ")"
     of SurrealRecordId:
         return "<record> " & $value.recordVal
     of SurrealString:
@@ -198,7 +210,19 @@ proc debugPrintSurrealValue*(value: SurrealValue): string =
                     ">.."
                 of Inclusive:
                     ">..="
-        return "<<SurrealRange>>(" & value.rangeStartVal.debugPrintSurrealValue & ")" & operator & "(" & value.rangeEndVal.debugPrintSurrealValue & ")"
+        case startBound:
+        of Inclusive, Exclusive:
+            case endBound:
+            of Inclusive, Exclusive:
+                return "<<SurrealRange>>(" & value.rangeStartVal.debugPrintSurrealValue & operator & value.rangeEndVal.debugPrintSurrealValue & ")"
+            of Unbounded:
+                return "<<SurrealRange>>(" & value.rangeStartVal.debugPrintSurrealValue & operator & "UNBOUNDED)"
+        of Unbounded:
+            case endBound:
+            of Inclusive, Exclusive:
+                return "<<SurrealRange>>(UNBOUNDED" & operator & value.rangeEndVal.debugPrintSurrealValue & ")"
+            of Unbounded:
+                return "<<SurrealRange>>(UNBOUNDED" & operator & "UNBOUNDED)"
     of SurrealRecordId:
         return "<<SurrealRecordId>>(" & $value.recordVal & ")"
     of SurrealString:

--- a/tests/cbor/decoding/test_cbor_decoder_range.nim
+++ b/tests/cbor/decoding/test_cbor_decoder_range.nim
@@ -22,7 +22,7 @@ suite "CBOR:Decoder:Range":
         check(decoded == newSurrealRange(%%% "Hi", %%% None, true, false))
 
     test "can decode range with only start bound":
-        var decoded = decode(@[0b110_11000'u8, 49, 0b100_00010'u8, 0b110_11000, 51, 0b000_00000, 0b110_00110, 0b111_10110])
+        var decoded = decode(@[0b110_11000'u8, 49, 0b100_00010'u8, 0b110_11000, 51, 0b000_00000, 0b111_10110])
         check(decoded.kind == SurrealRange)
         check(decoded.getRangeStart() == %%% 0)
         check(decoded.getRangeEnd() == surrealNone)
@@ -31,7 +31,7 @@ suite "CBOR:Decoder:Range":
         check(decoded == newSurrealStartOnlyRange(%%% 0, false))
 
     test "can decode range with only end bound":
-        var decoded = decode(@[0b110_11000'u8, 49, 0b100_00010'u8, 0b110_00110, 0b111_10110, 0b110_11000, 51, 0b110_00110, 0b111_10110])
+        var decoded = decode(@[0b110_11000'u8, 49, 0b100_00010'u8, 0b111_10110, 0b110_11000, 51, 0b110_00110, 0b111_10110])
         check(decoded.kind == SurrealRange)
         check(decoded.getRangeStart() == surrealNone)
         check(decoded.getRangeEnd() == surrealNone)

--- a/tests/cbor/encoding/test_cbor_encoder_range.nim
+++ b/tests/cbor/encoding/test_cbor_encoder_range.nim
@@ -16,9 +16,9 @@ suite "CBOR:Encoder:Range":
     test "should encode range with only start bound":
         var range = newSurrealStartOnlyRange(%%% 255, true)
         var bytes = encode(range).getOutput()
-        check(bytes == @[0b110_11000'u8, 49, 0b100_00010, 0b110_11000, 50, 0b000_11000, 255, 0b110_00110, 0b111_10110])
+        check(bytes == @[0b110_11000'u8, 49, 0b100_00010, 0b110_11000, 50, 0b000_11000, 255, 0b111_10110])
 
     test "should encode range with only end bound":
         var range = newSurrealEndOnlyRange(%%% "Hi", false)
         var bytes = encode(range).getOutput()
-        check(bytes == @[0b110_11000'u8, 49, 0b100_00010, 0b110_00110, 0b111_10110, 0b110_11000, 51, 0b011_00010, 0x48, 0x69])
+        check(bytes == @[0b110_11000'u8, 49, 0b100_00010, 0b111_10110, 0b110_11000, 51, 0b011_00010, 0x48, 0x69])


### PR DESCRIPTION
SurrealDB encodes NULL instead of NONE.

Also, fix stringification and improve logging